### PR TITLE
[FEAT] sign뷰 레이아웃 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.ahha_android" >
+    package="com.example.ahha_android">
 
     <application
         android:allowBackup="true"
@@ -8,18 +8,18 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Ahhaandroid" >
+        android:theme="@style/Theme.Ahhaandroid">
         <activity
             android:name=".ui.sign.SignActivity"
-            android:exported="true" />
-        <activity
-            android:name=".ui.main.MainActivity"
-            android:exported="true" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.main.MainActivity"
+            android:exported="true">
         </activity>
     </application>
 

--- a/app/src/main/java/com/example/ahha_android/ui/sign/SignActivity.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/sign/SignActivity.kt
@@ -1,12 +1,20 @@
 package com.example.ahha_android.ui.sign
 
+import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
 import com.example.ahha_android.R
 
 class SignActivity : AppCompatActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sign)
+
     }
 }

--- a/app/src/main/java/com/example/ahha_android/ui/sign/SignFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/sign/SignFragment.kt
@@ -5,15 +5,34 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
 import com.example.ahha_android.R
+import com.example.ahha_android.databinding.FragmentSignBinding
 
 class SignFragment : Fragment() {
+    private lateinit var binding: FragmentSignBinding
+    private val viewModel: SignViewModel by viewModels()
+    lateinit var navController: NavController
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_sign, container, false)
+    ): View {
+        binding = FragmentSignBinding.inflate(inflater, container, false)
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        navController = Navigation.findNavController(view)
+
+        binding.buttonSignUp.setOnClickListener{
+            navController.navigate(R.id.actionSignFragmentToSignPlantFragment)
+        }
     }
 }

--- a/app/src/main/java/com/example/ahha_android/ui/sign/SignViewModel.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/sign/SignViewModel.kt
@@ -1,0 +1,6 @@
+package com.example.ahha_android.ui.sign
+
+import androidx.lifecycle.ViewModel
+
+class SignViewModel : ViewModel() {
+}

--- a/app/src/main/res/layout/fragment_sign.xml
+++ b/app/src/main/res/layout/fragment_sign.xml
@@ -1,8 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     tools:context=".ui.sign.SignFragment">
 
-</FrameLayout>
+    <data>
+        <variable
+            name="viewModel"
+            type="com.example.ahha_android.ui.sign.SignViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+
+        <ImageView
+            android:id="@+id/imageViewLogo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="160dp"
+            android:src="@drawable/ic_launcher_background"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.498"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/buttonSignUp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sign_with_google"
+            android:layout_marginBottom="10dp"
+            app:layout_constraintBottom_toTopOf="@+id/textViewSignInfo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/textViewSignInfo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sign_info"
+            android:textAlignment="center"
+            android:layout_marginBottom="30dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="app_name">ahha-android</string>
+
+    <!-- SignFragment -->
+    <string name="sign_with_google">Google 계정으로 가입</string>
+    <string name="sign_info"><b>자주 사용하는 이메일과 동일한 계정</b>"으로 가입하세요.&#10;더욱 빠르게 환경을 지킬 수 있습니다."</string>
+
 </resources>


### PR DESCRIPTION
- 구글 로그인 연동 화면의 대략적인 레이아웃을 구현했습니다.
- 임시로 `sign` 패키지 하위에 `SignViewModel`을 추가했습니다.
- 구글 로그인 연동 버튼은 다음 화면(캐릭터 만들기)으로 넘어가도록 연결했습니다.