### PR TITLE
[FEAT] 캐릭터 히스토리 화면 레이아웃 구현 및 화면 연결

### DIFF
--- a/app/src/main/java/com/example/ahha_android/data/vo/PlantHistoryData.kt
+++ b/app/src/main/java/com/example/ahha_android/data/vo/PlantHistoryData.kt
@@ -1,0 +1,7 @@
+package com.example.ahha_android.data.vo
+
+data class PlantHistoryData(
+    val name: String,
+    val startTime: String,
+    val finishTime: String
+)

--- a/app/src/main/java/com/example/ahha_android/ui/main/PlantHistoryFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/PlantHistoryFragment.kt
@@ -1,0 +1,43 @@
+package com.example.ahha_android.ui.main
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
+import com.example.ahha_android.databinding.FragmentPlantHistoryBinding
+import com.example.ahha_android.ui.main.adapter.PlantHistoryAdapter
+import com.example.ahha_android.ui.viewmodel.PlantHistoryViewModel
+
+class PlantHistoryFragment : Fragment() {
+    private lateinit var binding: FragmentPlantHistoryBinding
+    private val viewModel: PlantHistoryViewModel by viewModels()
+    private lateinit var plantHistoryAdapter: PlantHistoryAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentPlantHistoryBinding.inflate(inflater, container, false)
+
+        initRecyclerView()
+        addObserver()
+
+        return binding.root
+    }
+
+    private fun initRecyclerView() {
+        plantHistoryAdapter = PlantHistoryAdapter()
+        binding.recyclerViewPlantHistory.adapter = plantHistoryAdapter
+        binding.recyclerViewPlantHistory.layoutManager = GridLayoutManager(requireContext(), 3)
+    }
+
+    private fun addObserver() {
+        viewModel.plantHistoryData.observe(viewLifecycleOwner) {
+            plantHistoryAdapter.data = it
+            plantHistoryAdapter.notifyDataSetChanged()
+        }
+    }
+}

--- a/app/src/main/java/com/example/ahha_android/ui/main/adapter/PlantHistoryAdapter.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/adapter/PlantHistoryAdapter.kt
@@ -1,0 +1,36 @@
+package com.example.ahha_android.ui.main.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.ahha_android.R
+import com.example.ahha_android.data.vo.PlantHistoryData
+import com.example.ahha_android.databinding.ItemPlantHistoryBinding
+
+class PlantHistoryAdapter() : RecyclerView.Adapter<PlantHistoryViewHolder>() {
+    var data = listOf<PlantHistoryData>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlantHistoryViewHolder {
+        val binding =
+            ItemPlantHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PlantHistoryViewHolder(binding, parent.context)
+    }
+
+    override fun onBindViewHolder(holder: PlantHistoryViewHolder, position: Int) {
+        holder.bind(data[position])
+    }
+
+    override fun getItemCount(): Int = data.size
+}
+
+class PlantHistoryViewHolder(
+    private val binding: ItemPlantHistoryBinding,
+    private val context: Context
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(data: PlantHistoryData) {
+        binding.textViewPlantName.text = data.name
+        binding.textViewPlantTime.text =
+            context.getString(R.string.plant_history_time_format, data.startTime, data.finishTime)
+    }
+}

--- a/app/src/main/java/com/example/ahha_android/ui/viewmodel/PlantHistoryViewModel.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/viewmodel/PlantHistoryViewModel.kt
@@ -1,0 +1,26 @@
+package com.example.ahha_android.ui.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.ahha_android.data.vo.PlantHistoryData
+
+class PlantHistoryViewModel : ViewModel() {
+    private val _plantHistoryData = MutableLiveData<List<PlantHistoryData>>()
+    val plantHistoryData: LiveData<List<PlantHistoryData>>
+        get() = _plantHistoryData
+
+    init {
+        fetchPlantHistoryData()
+    }
+
+    private fun fetchPlantHistoryData() {
+        _plantHistoryData.value = listOf(
+            PlantHistoryData("토마토", "2021.12.08", "2022.01.31"),
+            PlantHistoryData("감자", "2021.12.08", "2022.01.31"),
+            PlantHistoryData("양파", "2021.12.08", "2022.01.31"),
+            PlantHistoryData("브로콜리", "2021.12.08", "2022.01.31"),
+            PlantHistoryData("오이", "2021.12.08", "2022.01.31"),
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -6,6 +6,10 @@
 
     <data>
 
+        <import type="com.example.ahha_android.R" />
+
+        <import type="androidx.navigation.Navigation" />
+
         <variable
             name="viewModel"
             type="com.example.ahha_android.ui.viewmodel.MainViewModel" />
@@ -47,7 +51,8 @@
                     android:id="@+id/imageViewHistory"
                     android:layout_width="48dp"
                     android:layout_height="48dp"
-                    android:layout_gravity="end" />
+                    android:layout_gravity="end"
+                    android:onClick="@{v -> Navigation.findNavController(v).navigate(R.id.actionMainFragmentToPlantHistoryFragment)}" />
 
             </androidx.appcompat.widget.Toolbar>
 
@@ -70,6 +75,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="10dp"
+            android:onClick="@{v -> Navigation.findNavController(v).navigate(R.id.actionMainFragmentToEditPlantFragment)}"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintTop_toBottomOf="@id/textViewTitle" />
 

--- a/app/src/main/res/layout/fragment_plant_history.xml
+++ b/app/src/main/res/layout/fragment_plant_history.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".ui.main.PlantHistoryFragment">
+
+    <data>
+
+        <import type="com.example.ahha_android.R" />
+
+        <import type="androidx.navigation.Navigation" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            app:elevation="0dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@android:color/transparent"
+                app:contentInsetStart="0dp">
+
+                <ImageView
+                    android:id="@+id/imageViewBack"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="start"
+                    android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textColor="@color/black"
+                    android:textSize="16dp"
+                    tools:text="캐릭터 히스토리" />
+
+            </androidx.appcompat.widget.Toolbar>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewPlantHistory"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="20dp"
+            android:clipToPadding="false"
+            android:overScrollMode="never"
+            android:paddingBottom="20dp" />
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_plant_history.xml
+++ b/app/src/main/res/layout/item_plant_history.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="15dp"
+        android:paddingVertical="20dp">
+
+        <TextView
+            android:id="@+id/textViewPlantName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:gravity="center"
+            android:textColor="#838383"
+            android:textSize="14dp"
+            tools:text="캐릭터 이름" />
+
+        <TextView
+            android:id="@+id/textViewPlantTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="10dp"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:textSize="14dp"
+            tools:text="2021.12.08\n~\n2022.01.31" />
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -16,6 +16,10 @@
             app:destination="@id/editPlantFragment" />
 
         <action
+            android:id="@+id/actionMainFragmentToPlantHistoryFragment"
+            app:destination="@id/plantHistoryFragment" />
+
+        <action
             android:id="@+id/actionMainFragmentToSettingFragment"
             app:destination="@id/settingFragment" />
 
@@ -26,6 +30,12 @@
         android:name="com.example.ahha_android.ui.main.EditPlantFragment"
         android:label="EditPlantFragment"
         tools:layout="@layout/fragment_edit_plant" />
+
+    <fragment
+        android:id="@+id/plantHistoryFragment"
+        android:name="com.example.ahha_android.ui.main.PlantHistoryFragment"
+        android:label="PlantHistoryFragment"
+        tools:layout="@layout/fragment_plant_history" />
 
     <fragment
         android:id="@+id/settingFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="sign_with_google">Google 계정으로 가입</string>
     <string name="sign_info"><b>자주 사용하는 이메일과 동일한 계정</b>"으로 가입하세요.&#10;더욱 빠르게 환경을 지킬 수 있습니다."</string>
 
+    <!-- PlantHistoryFragment -->
+    <string name="plant_history_time_format">%s\n~\n%s</string>
 </resources>


### PR DESCRIPTION
- 캐릭터 히스토리 화면의 대략적인 레이아웃을 구현했습니다.
- 추가된 화면을 `navigation`에 추가하고, `메인` - `캐릭터 변경` 및 `메인` - `캐릭터 히스토리` 화면을 연결했습니다.
- `data` - `vo` 패키지 하위에 `PlantHistoryData.kt` data class 파일을 추가했습니다.