### PR TITLE
[FEAT] 설정의 이메일 삭제 알림 화면 레이아웃 구현

### DIFF
--- a/app/src/main/java/com/example/ahha_android/ui/setting/SettingNotificationFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/setting/SettingNotificationFragment.kt
@@ -1,19 +1,20 @@
 package com.example.ahha_android.ui.setting
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.example.ahha_android.R
+import androidx.fragment.app.Fragment
+import com.example.ahha_android.databinding.FragmentSettingNotificationBinding
 
 class SettingNotificationFragment : Fragment() {
+    private lateinit var binding: FragmentSettingNotificationBinding
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_setting_notification, container, false)
+    ): View {
+        binding = FragmentSettingNotificationBinding.inflate(inflater, container, false)
+        return binding.root
     }
 }

--- a/app/src/main/java/com/example/ahha_android/ui/setting/SettingNotificationFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/setting/SettingNotificationFragment.kt
@@ -5,16 +5,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.example.ahha_android.databinding.FragmentSettingNotificationBinding
+import com.example.ahha_android.ui.viewmodel.SettingViewModel
 
 class SettingNotificationFragment : Fragment() {
     private lateinit var binding: FragmentSettingNotificationBinding
+    private val viewModel: SettingViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentSettingNotificationBinding.inflate(inflater, container, false)
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
+
         return binding.root
     }
 }

--- a/app/src/main/java/com/example/ahha_android/ui/viewmodel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/viewmodel/SettingViewModel.kt
@@ -1,0 +1,37 @@
+package com.example.ahha_android.ui.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class SettingViewModel : ViewModel() {
+    private val _notificationCount = MutableLiveData<Int>()
+    val notificationCount: LiveData<Int>
+        get() = _notificationCount
+
+    init {
+        initNotificationCount()
+    }
+
+    private fun initNotificationCount() {
+        _notificationCount.value = 0
+    }
+
+    fun increaseNotificationCount() {
+        _notificationCount.value = _notificationCount.value?.plus(10)
+    }
+
+    fun reduceNotificationCount() {
+        if (_notificationCount.value?.compareTo(10) == -1) {
+            _notificationCount.value = 0
+        } else {
+            _notificationCount.value = _notificationCount.value?.minus(10)
+        }
+    }
+
+    fun onNotificationCountTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+        if (s.isNotEmpty()) {
+            _notificationCount.value = s.toString().toInt()
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_plant_history.xml
+++ b/app/src/main/res/layout/fragment_plant_history.xml
@@ -21,8 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/transparent"
-            app:elevation="0dp"
-            app:layout_constraintTop_toTopOf="parent">
+            app:elevation="0dp">
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -21,8 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/transparent"
-            app:elevation="0dp"
-            app:layout_constraintTop_toTopOf="parent">
+            app:elevation="0dp">
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_setting_notification.xml
+++ b/app/src/main/res/layout/fragment_setting_notification.xml
@@ -1,8 +1,150 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     tools:context=".ui.setting.SettingNotificationFragment">
 
-</FrameLayout>
+    <data>
+
+        <import type="com.example.ahha_android.R" />
+
+        <import type="androidx.navigation.Navigation" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            app:elevation="0dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@android:color/transparent"
+                app:contentInsetStart="0dp">
+
+                <ImageView
+                    android:id="@+id/imageViewBack"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="start"
+                    android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textColor="@color/black"
+                    android:textSize="16dp"
+                    tools:text="이메일 삭제 알림" />
+
+            </androidx.appcompat.widget.Toolbar>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <LinearLayout
+            android:id="@+id/linearLayoutPushNotification"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="20dp"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toBottomOf="@id/appBarLayout">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="1"
+                android:textColor="@color/black"
+                android:textSize="15dp"
+                tools:text="푸시 알림" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switchPushNotification"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textViewSettingNotificationCountTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:textColor="@color/black"
+            android:textSize="15dp"
+            app:layout_constraintStart_toStartOf="@id/linearLayoutPushNotification"
+            app:layout_constraintTop_toBottomOf="@id/linearLayoutPushNotification"
+            tools:text="개수 설정" />
+
+        <LinearLayout
+            android:id="@+id/linearLayout2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintTop_toBottomOf="@id/textViewSettingNotificationCountTitle"
+            tools:layout_editor_absoluteX="20dp">
+
+            <TextView
+                android:id="@+id/buttonMinus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="20dp"
+                android:paddingVertical="10dp"
+                android:text="-"
+                android:textColor="@color/black"
+                android:textSize="20dp" />
+
+            <EditText
+                android:id="@+id/editTextNotificationCount"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="center"
+                android:paddingHorizontal="20dp"
+                android:paddingVertical="10dp"
+                android:text="50"
+                android:textColor="@color/black"
+                android:textSize="15dp" />
+
+            <TextView
+                android:id="@+id/buttonPlus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="20dp"
+                android:paddingVertical="10dp"
+                android:text="+"
+                android:textColor="@color/black"
+                android:textSize="20dp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textViewComplete"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp"
+            android:background="#CDCDCD"
+            android:gravity="center"
+            android:paddingVertical="15dp"
+            android:textColor="@color/black"
+            android:textSize="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="설정 완료" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_setting_notification.xml
+++ b/app/src/main/res/layout/fragment_setting_notification.xml
@@ -9,6 +9,10 @@
         <import type="com.example.ahha_android.R" />
 
         <import type="androidx.navigation.Navigation" />
+
+        <variable
+            name="viewModel"
+            type="com.example.ahha_android.ui.viewmodel.SettingViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -99,6 +103,7 @@
                 android:id="@+id/buttonMinus"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:onClick="@{() -> viewModel.reduceNotificationCount()}"
                 android:paddingHorizontal="20dp"
                 android:paddingVertical="10dp"
                 android:text="-"
@@ -115,7 +120,8 @@
                 android:gravity="center"
                 android:paddingHorizontal="20dp"
                 android:paddingVertical="10dp"
-                android:text="50"
+                android:onTextChanged="@{viewModel::onNotificationCountTextChanged}"
+                android:text="@{viewModel.notificationCount.toString()}"
                 android:textColor="@color/black"
                 android:textSize="15dp" />
 
@@ -123,6 +129,7 @@
                 android:id="@+id/buttonPlus"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:onClick="@{() -> viewModel.increaseNotificationCount()}"
                 android:paddingHorizontal="20dp"
                 android:paddingVertical="10dp"
                 android:text="+"


### PR DESCRIPTION
- 설정의 이메일 삭제 알림 화면의 대략적인 레이아웃을 구현했습니다.
- `SettingViewModel`을 생성하고, 이메일 삭제 알림 화면에 포함된 switch의 기능을 구현했습니다.
- 툴바의 불필요한 제약조건을 삭제했습니다.