### PR TITLE
[FEAT] 캐릭터 히스토리 서버 연동

### DIFF
--- a/app/src/main/java/com/example/ahha_android/data/response/ResponsePlantHistoryData.kt
+++ b/app/src/main/java/com/example/ahha_android/data/response/ResponsePlantHistoryData.kt
@@ -1,0 +1,29 @@
+package com.example.ahha_android.data.response
+
+import com.example.ahha_android.data.type.Plant
+import com.example.ahha_android.data.vo.PlantHistoryData
+import com.example.ahha_android.util.convertDateToStringFormat
+
+data class ResponsePlantHistoryData(
+    val code: Int,
+    val data: List<PlantHistoryResponseData>,
+    val message: String
+)
+
+data class PlantHistoryResponseData(
+    val finishTime: String,
+    val id: Int,
+    val kind: String,
+    val name: String,
+    val startTime: String
+) {
+    companion object {
+        fun from(data: PlantHistoryResponseData): PlantHistoryData {
+            val name = data.name
+            val startTime = convertDateToStringFormat(data.startTime)
+            val finishTime = convertDateToStringFormat(data.finishTime)
+            val kind = Plant.valueOf(data.kind)
+            return PlantHistoryData(name, startTime, finishTime, kind)
+        }
+    }
+}

--- a/app/src/main/java/com/example/ahha_android/data/service/PlantHistoryService.kt
+++ b/app/src/main/java/com/example/ahha_android/data/service/PlantHistoryService.kt
@@ -1,4 +1,12 @@
 package com.example.ahha_android.data.service
 
+import com.example.ahha_android.data.response.ResponsePlantHistoryData
+import retrofit2.http.GET
+import retrofit2.http.Header
+
 interface PlantHistoryService {
+    @GET("plant-history")
+    suspend fun getPlantHistory(
+        @Header("Authorization") token: String
+    ): ResponsePlantHistoryData
 }

--- a/app/src/main/java/com/example/ahha_android/data/type/Plant.kt
+++ b/app/src/main/java/com/example/ahha_android/data/type/Plant.kt
@@ -7,7 +7,7 @@ enum class Plant {
     TOMATO,
     BROCCOLI;
 
-    fun getPlantImage(level: Int): Int {
+    fun getPlantImageByLevel(level: Int): Int {
         return when (this) {
             GREENONION -> {
                 when (level) {
@@ -36,6 +36,22 @@ enum class Plant {
                     else -> R.drawable.ic_launcher_foreground
                 }
             }
+        }
+    }
+
+    fun getPlantFrontImage(): Int {
+        return when (this) {
+            GREENONION -> R.drawable.ic_launcher_foreground
+            TOMATO -> R.drawable.ic_launcher_foreground
+            BROCCOLI -> R.drawable.ic_launcher_foreground
+        }
+    }
+
+    fun getPlantBackImage(): Int {
+        return when (this) {
+            GREENONION -> R.drawable.ic_launcher_background
+            TOMATO -> R.drawable.ic_launcher_background
+            BROCCOLI -> R.drawable.ic_launcher_background
         }
     }
 }

--- a/app/src/main/java/com/example/ahha_android/data/vo/PlantHistoryData.kt
+++ b/app/src/main/java/com/example/ahha_android/data/vo/PlantHistoryData.kt
@@ -1,7 +1,10 @@
 package com.example.ahha_android.data.vo
 
+import com.example.ahha_android.data.type.Plant
+
 data class PlantHistoryData(
     val name: String,
     val startTime: String,
-    val finishTime: String
+    val finishTime: String,
+    val kind: Plant
 )

--- a/app/src/main/java/com/example/ahha_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/MainFragment.kt
@@ -39,7 +39,7 @@ class MainFragment : Fragment() {
 
         viewModel.plantKind.observe(viewLifecycleOwner) {
             viewModel.plantLevel.value?.let { level ->
-                binding.imageViewPlant.setDrawableImage(it.getPlantImage(level))
+                binding.imageViewPlant.setDrawableImage(it.getPlantImageByLevel(level))
             }
         }
     }

--- a/app/src/main/java/com/example/ahha_android/ui/main/adapter/PlantHistoryAdapter.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/adapter/PlantHistoryAdapter.kt
@@ -8,8 +8,10 @@ import android.view.animation.AnimationUtils
 import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.RecyclerView
 import com.example.ahha_android.R
+import com.example.ahha_android.data.type.Plant
 import com.example.ahha_android.data.vo.PlantHistoryData
 import com.example.ahha_android.databinding.ItemPlantHistoryBinding
+import com.example.ahha_android.util.BindingAdapter.setDrawableImage
 
 class PlantHistoryAdapter : RecyclerView.Adapter<PlantHistoryViewHolder>() {
     var data = listOf<PlantHistoryData>()
@@ -34,11 +36,14 @@ class PlantHistoryViewHolder(
     private lateinit var animationToMiddle: Animation
     private lateinit var animationFromMiddle: Animation
     private var isFrontOfCardShowing = true
+    private lateinit var plantKind: Plant
 
     fun bind(data: PlantHistoryData) {
         binding.textViewPlantName.text = data.name
         binding.textViewPlantTime.text =
             context.getString(R.string.plant_history_time_format, data.startTime, data.finishTime)
+        binding.imageViewPlant.setDrawableImage(data.kind.getPlantFrontImage())
+        plantKind = data.kind
 
         animationToMiddle = AnimationUtils.loadAnimation(context, R.anim.to_middle)
         animationFromMiddle = AnimationUtils.loadAnimation(context, R.anim.from_middle)
@@ -60,13 +65,13 @@ class PlantHistoryViewHolder(
                 binding.apply {
                     textViewPlantName.isInvisible = false
                     textViewPlantTime.isInvisible = false
-                    imageViewPlant.setBackgroundColor(context.resources.getColor(R.color.grey2))
+                    binding.imageViewPlant.setDrawableImage(plantKind.getPlantBackImage())
                 }
             } else {
                 binding.apply {
                     textViewPlantName.isInvisible = true
                     textViewPlantTime.isInvisible = true
-                    imageViewPlant.setBackgroundColor(context.resources.getColor(R.color.lime))
+                    binding.imageViewPlant.setDrawableImage(plantKind.getPlantFrontImage())
                 }
             }
             binding.apply {

--- a/app/src/main/java/com/example/ahha_android/ui/viewmodel/PlantHistoryViewModel.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/viewmodel/PlantHistoryViewModel.kt
@@ -3,24 +3,36 @@ package com.example.ahha_android.ui.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.ahha_android.data.response.PlantHistoryResponseData
+import com.example.ahha_android.data.service.RetrofitBuilder
 import com.example.ahha_android.data.vo.PlantHistoryData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
 
 class PlantHistoryViewModel : ViewModel() {
     private val _plantHistoryData = MutableLiveData<List<PlantHistoryData>>()
     val plantHistoryData: LiveData<List<PlantHistoryData>>
         get() = _plantHistoryData
 
+    // FIXME
+    private val token =
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTY0Mzk4OTg2MiwiZXhwIjoxNjc1NTI1ODYyfQ.yqv6dqYNbIPnAeLMi0-T6N7Bjf2GlcEsNJ8ysh9cWy8"
+
     init {
-        fetchPlantHistoryData()
+        viewModelScope.launch(Dispatchers.IO) {
+            fetchPlantHistoryData()
+        }
     }
 
-    private fun fetchPlantHistoryData() {
-        _plantHistoryData.value = listOf(
-            PlantHistoryData("토마토", "2021.12.08", "2022.01.31"),
-            PlantHistoryData("감자", "2021.12.08", "2022.01.31"),
-            PlantHistoryData("양파", "2021.12.08", "2022.01.31"),
-            PlantHistoryData("브로콜리", "2021.12.08", "2022.01.31"),
-            PlantHistoryData("오이", "2021.12.08", "2022.01.31"),
-        )
+    private suspend fun fetchPlantHistoryData() {
+        try {
+            val response: List<PlantHistoryResponseData> =
+                RetrofitBuilder.plantHistoryService.getPlantHistory(token).data
+            _plantHistoryData.postValue(response.map { PlantHistoryResponseData.from(it) })
+        } catch (e: HttpException) {
+            e.printStackTrace()
+        }
     }
 }

--- a/app/src/main/java/com/example/ahha_android/util/Extension.kt
+++ b/app/src/main/java/com/example/ahha_android/util/Extension.kt
@@ -1,0 +1,10 @@
+package com.example.ahha_android.util
+
+import java.text.SimpleDateFormat
+
+fun convertDateToStringFormat(date: String): String {
+    val inputDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val inputDate = inputDateFormat.parse(date)
+    val dateFormat = SimpleDateFormat("yyyy.MM.dd")
+    return dateFormat.format(inputDate)
+}

--- a/app/src/main/res/layout/item_plant_history.xml
+++ b/app/src/main/res/layout/item_plant_history.xml
@@ -13,7 +13,6 @@
             android:id="@+id/imageViewPlant"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:background="@color/lime"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
- 캐릭터 히스토리 화면의 서버를 연동했습니다.
- 캐릭터 히스토리의 각 리사이클러뷰 아이템이 어떤 식물인지에 따라 해당 아이템의 이미지가 바뀌도록 구현했습니다.
    - `getPlantFrontImage`
    - `getPlantBackImage`
- `util` - `extension` 파일을 생성하고, 확장함수를 구현했습니다.