### PR TITLE
[fix] 식물 생성 시 이름 null값 처리

### DIFF
--- a/app/src/main/java/com/example/ahha_android/ui/sign/SignPlantNameFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/sign/SignPlantNameFragment.kt
@@ -61,7 +61,9 @@ class SignPlantNameFragment : Fragment() {
             if (!binding.editTextCharacterName.text.isNullOrBlank()) {
                 binding.buttonFinish.isActivated = true
                 initClickListener()
-            }
+            } else {
+            binding.buttonFinish.isActivated = false
+                }
         }
     }
 


### PR DESCRIPTION
- 식물 생성 시 이름이 null값인 경우 버튼 활성화되지 않도록 처리했습니다.