### PR TITLE
[fix] 다이얼로그 이름 관련 텍스트 수정

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
 
     <!-- CompleteDialogFragment -->
     <string name="complete_dialog_congratulations">Congratulations!</string>
-    <string name="complete_dialog_done">가 다 자랐어요</string>
+    <string name="complete_dialog_done">! 다 자랐어요</string>
     <string name="complete_dialog_close">닫기</string>
     <string name="complete_dialog_exchange">식물 교환</string>
 


### PR DESCRIPTION
- 다이얼로그에 식물 이름이 영어이거나 받침있게 끝나는 경우를 고려하여 텍스트를 수정하였습니다.