### PR TITLE
[fix] 다이얼로그 닫기 -> 새로키우기 수정

### DIFF
--- a/app/src/main/java/com/example/ahha_android/ui/main/CompleteDialogFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/CompleteDialogFragment.kt
@@ -53,7 +53,7 @@ class CompleteDialogFragment : DialogFragment() {
         }
 
         binding.buttonFinish.setOnClickListener {
-            Log.d("************clicked","닫기")
+            Log.d("************clicked","새로 키우기")
             buttonClickListener.onFinishClicked()
             dismiss()
         }

--- a/app/src/main/java/com/example/ahha_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/MainFragment.kt
@@ -42,7 +42,6 @@ class MainFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         navController = Navigation.findNavController(view)
     }
 
@@ -82,9 +81,9 @@ class MainFragment : Fragment() {
         }
     }
 
-    private fun allGrownUp(){
+    private fun allGrownUp() {
         viewModel.plantScore.observe(viewLifecycleOwner) {
-            Log.d("**************Score:", it.toString())
+            Log.d("***************Score", it.toString())
             if (it >= 25) {
                 showDialog()
             }
@@ -101,6 +100,7 @@ class MainFragment : Fragment() {
             override fun onExchangeClicked() {
                 navController.navigate(R.id.actionMainFragmentToPlantExchangeFragment, bundle)
             }
+
             override fun onFinishClicked() {
                 navController.navigate(R.id.actionMainFragmentToSignPlantFragment, bundle)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
     <!-- CompleteDialogFragment -->
     <string name="complete_dialog_congratulations">Congratulations!</string>
     <string name="complete_dialog_done">! 다 자랐어요</string>
-    <string name="complete_dialog_close">닫기</string>
+    <string name="complete_dialog_close">새로 키우기</string>
     <string name="complete_dialog_exchange">식물 교환</string>
 
     <!-- TODO: Remove or change this placeholder text -->


### PR DESCRIPTION
- 다이얼로그 닫기 -> 새로 키우기로 수정하였습니다. 

+) 다이얼로그가 첫 화면 진입시에는 정상적으로 뜨는데 다른 화면을 거쳐온 후에는 두 번 떠서 두 번 닫아줘야 하는 상태입니다.
이걸 고쳐보려고 했는데 너무 시간이 오래 걸려서요,
시연 영상 녹화 시에는 우선 메인 진입 후 이 다이얼로그가 뜨면 바로 새로 키우기로 넘어가는 식으로 해야 할 듯 합니다,,