### PR TITLE
[fix] 캐릭터 히스토리에서 배송받을 수 있는 식물 개수 변경 및 화면 진입 시 바로 stroke 처리가 되도록 수정

### DIFF
--- a/app/src/main/java/com/example/ahha_android/ui/main/adapter/PlantHistoryAdapter.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/adapter/PlantHistoryAdapter.kt
@@ -37,7 +37,7 @@ class PlantHistoryViewHolder(
     private lateinit var animationFromMiddle: Animation
     private var isFrontOfCardShowing = true
     private lateinit var plantKind: Plant
-    private val exchangedIndex = listOf(0, 2)
+    private val exchangedIndex = listOf(0, 1, 4)
     private var pos = -1
 
     fun bind(data: PlantHistoryData, position: Int) {
@@ -47,6 +47,12 @@ class PlantHistoryViewHolder(
         binding.imageViewPlant.setDrawableImage(data.kind.getPlantImage())
         plantKind = data.kind
         pos = position
+
+        if (exchangedIndex.contains(pos)) {
+            binding.viewOval.setBackgroundResource(R.drawable.oval_plant_history_front_checked)
+        } else {
+            binding.viewOval.setBackgroundResource(R.drawable.oval_plant_history_front)
+        }
 
         animationToMiddle = AnimationUtils.loadAnimation(context, R.anim.to_middle)
         animationToMiddle.setAnimationListener(this)

--- a/app/src/main/res/layout/item_plant_history.xml
+++ b/app/src/main/res/layout/item_plant_history.xml
@@ -22,7 +22,6 @@
                 android:layout_height="match_parent"
                 android:layout_marginHorizontal="4dp"
                 android:layout_marginVertical="8dp"
-                android:background="@drawable/oval_plant_history_front"
                 android:elevation="5dp" />
 
             <ImageView


### PR DESCRIPTION
- 캐릭터 히스토리 화면에서 배송받을 수 있는 식물의 개수를 세개로 변경했습니다.
- 캐릭터 히스토리 화면 진입 시 배송받을 수 있는 식물의 앞면에 바로 stroke 처리가 될 수 있도록 수정했습니다.