### PR TITLE
[feat] 식물 생성 버그 및 디테일 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <package android:name="com.google.android.gm" />
+    </queries>
+
     <application
         android:name=".EasyPeasyApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/ahha_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/main/MainFragment.kt
@@ -35,6 +35,7 @@ class MainFragment : Fragment() {
 
         init()
         addObserver()
+        addListener()
         allGrownUp()
 
         return binding.root
@@ -81,6 +82,12 @@ class MainFragment : Fragment() {
         }
     }
 
+    private fun addListener() {
+        binding.textViewMailBoxManage.setOnClickListener {
+            goToGmail()
+        }
+    }
+
     private fun allGrownUp() {
         viewModel.plantScore.observe(viewLifecycleOwner) {
             Log.d("***************Score", it.toString())
@@ -106,5 +113,11 @@ class MainFragment : Fragment() {
             }
         })
         fragmentManager?.let { dialogView.show(it, "tag") }
+    }
+
+    private fun goToGmail() {
+        val gmailPackage = "com.google.android.gm"
+        val intent = requireActivity().packageManager.getLaunchIntentForPackage(gmailPackage)
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/example/ahha_android/ui/setting/SettingNotificationFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/setting/SettingNotificationFragment.kt
@@ -5,14 +5,13 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.navArgs
 import com.example.ahha_android.R
 import com.example.ahha_android.databinding.FragmentSettingNotificationBinding
 import com.example.ahha_android.ui.viewmodel.SettingViewModel
 import com.example.ahha_android.util.setStatusBarColor
-import kotlin.properties.Delegates
 
 class SettingNotificationFragment : Fragment() {
     private lateinit var binding: FragmentSettingNotificationBinding
@@ -63,6 +62,7 @@ class SettingNotificationFragment : Fragment() {
         val notificationString = arguments?.getString("notificationString")
 
         binding.textViewComplete.setOnClickListener {
+            Toast.makeText(requireContext(), "Modifications Completed!", Toast.LENGTH_SHORT).show()
             Log.d("***********************", "send to server")
             Log.d("*********notificationOn", notificationString.toString())
             Log.d("******notificationLimit", notificationLimit.toString())

--- a/app/src/main/java/com/example/ahha_android/ui/sign/SignPlantNameFragment.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/sign/SignPlantNameFragment.kt
@@ -9,10 +9,11 @@ import android.view.ViewGroup
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import com.example.ahha_android.R
+import com.example.ahha_android.data.EasyPeasySharedPreference
 import com.example.ahha_android.databinding.FragmentSignPlantNameBinding
 import com.example.ahha_android.ui.main.MainActivity
-import com.example.ahha_android.ui.viewmodel.EditPlantViewModel
 import com.example.ahha_android.ui.viewmodel.ResetViewModel
 import com.example.ahha_android.ui.viewmodel.SignViewModel
 import com.example.ahha_android.util.BindingAdapter.setDrawableImage
@@ -21,7 +22,7 @@ import com.example.ahha_android.util.setStatusBarColor
 class SignPlantNameFragment : Fragment() {
     private lateinit var binding: FragmentSignPlantNameBinding
     private val signViewModel: SignViewModel by activityViewModels()
-    private val resetViewModel: ResetViewModel by activityViewModels()
+    private val resetViewModel: ResetViewModel by viewModels()
     lateinit var kind: String
 
     override fun onCreateView(
@@ -38,9 +39,6 @@ class SignPlantNameFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        resetViewModel.fetchPlant()
-
         setCharacterImage()
         checkInputBlank()
     }
@@ -80,15 +78,9 @@ class SignPlantNameFragment : Fragment() {
             val characterNum = arguments?.getInt("characterNum")
             if (characterNum != null) {
                 when (characterNum) {
-                    1 -> {
-                        kind = "GREENONION"
-                    }
-                    2 -> {
-                        kind = "TOMATO"
-                    }
-                    3 -> {
-                        kind = "BROCCOLI"
-                    }
+                    1 -> kind = "GREENONION"
+                    2 -> kind = "TOMATO"
+                    3 -> kind = "BROCCOLI"
                 }
             }
             onFinish()
@@ -97,25 +89,19 @@ class SignPlantNameFragment : Fragment() {
 
 
     private fun onFinish(){
+        makePlant()
         val intent = Intent(activity, MainActivity::class.java)
         startActivity(intent)
         requireActivity().finish()
-
-        resetViewModel.fetchPlant()
-        makePlant()
     }
 
 
     private fun makePlant() {
         val name = binding.editTextCharacterName.text
-        resetViewModel.plantLevel.observe(viewLifecycleOwner) {
-            if (it < 1) {
-                signViewModel.createPlant(name, kind)
-                Log.d("*********Create:", it.toString())
-            } else {
-                resetViewModel.resetPlant(name, kind)
-                Log.d("*********Reset:", it.toString())
-            }
+        if (EasyPeasySharedPreference.getAccessToken().isNullOrBlank()) {
+            signViewModel.createPlant(name, kind)
+        } else {
+            resetViewModel.resetPlant(name, kind)
         }
     }
 }

--- a/app/src/main/java/com/example/ahha_android/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/viewmodel/MainViewModel.kt
@@ -15,8 +15,6 @@ import com.example.ahha_android.data.type.Plant
 import retrofit2.HttpException
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
-    private val context = application
-
     private val token = "Bearer ${EasyPeasySharedPreference.getAccessToken()}"
 
     private val _userInfo = MutableLiveData<UserData>()
@@ -78,12 +76,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         } catch (e: HttpException) {
             e.printStackTrace()
         }
-    }
-
-    fun goToGmail() {
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = Uri.parse("https://mail.google.com")
-        context.startActivity(intent.addFlags(FLAG_ACTIVITY_NEW_TASK))
     }
 
     fun setCurrentPositionIsLast(value: Boolean) {

--- a/app/src/main/java/com/example/ahha_android/ui/viewmodel/SignViewModel.kt
+++ b/app/src/main/java/com/example/ahha_android/ui/viewmodel/SignViewModel.kt
@@ -10,11 +10,8 @@ import com.example.ahha_android.R
 import com.example.ahha_android.data.EasyPeasySharedPreference
 import com.example.ahha_android.data.model.request.RequestLoginData
 import com.example.ahha_android.data.model.request.RequestPlantCreateData
-import com.example.ahha_android.data.model.request.RequestPlantResetData
 import com.example.ahha_android.data.model.response.ResponsePlantCreateData
-import com.example.ahha_android.data.model.response.ResponsePlantResetData
 import com.example.ahha_android.data.service.RetrofitBuilder
-import com.example.ahha_android.data.type.Plant
 import com.example.ahha_android.data.vo.SignPlantData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -36,8 +33,6 @@ class SignViewModel(application: Application) : AndroidViewModel(application) {
     private val _accessToken = MutableLiveData<String?>()
     val accessToken: LiveData<String?>
         get() = _accessToken
-
-    private val token = "Bearer ${EasyPeasySharedPreference.getAccessToken()}"
 
     fun loginUser(authCode: String?, pushToken: String) = viewModelScope.launch(Dispatchers.IO) {
         try {

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -242,7 +242,6 @@
                 android:fontFamily="@font/apple_sd_gothic_neo_bold"
                 android:gravity="center"
                 android:includeFontPadding="false"
-                android:onClick="@{() -> viewModel.goToGmail()}"
                 android:paddingHorizontal="18dp"
                 android:paddingVertical="16dp"
                 android:text="@string/main_mail_box_manage"

--- a/app/src/main/res/layout/fragment_plant_exchange.xml
+++ b/app/src/main/res/layout/fragment_plant_exchange.xml
@@ -151,7 +151,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/apple_sd_gothic_neo_bold"
-                android:text="4"
+                android:text="3"
                 android:textColor="@color/grey6"
                 android:textSize="13dp"
                 app:layout_constraintBottom_toBottomOf="@+id/textViewPossible"


### PR DESCRIPTION
- `goToGmail` 함수 실행 시, gmail 웹이 아닌 앱으로 바로 연동되도록 수정했습니다.
- 식물 최대 교환 가능 개수를 4개에서 3개로 변경했습니다.
- 메일 삭제 알림 설정 화면의 설정 완료 버튼 클릭 시 토스트 메시지가 보이도록 수정했습니다.
- 식물 생성에서 발생한 버그를 수정했습니다.
    - 사용자가 키운 식물의 레벨을 확인하여 분기하는 방식에서 사용자의 내부db에 저장된 accessToken을 확인하는 방식으로 수정했습니다.